### PR TITLE
New Boxer output

### DIFF
--- a/BOXER_OUTPUT_README.txt
+++ b/BOXER_OUTPUT_README.txt
@@ -1,0 +1,13 @@
+The Boxer output (-o boxer) is a modification of the Prolog output, with the following changes:
+
+- Terminal nodes are printed directly inside the tree, rather than just referenced
+- Made terminal nodes a ternary predicate with its category, string and list containing all other features
+- Input no longer needs to be POS & NER tagged, but these features will still appear in the output if available
+- Changed Prolog file header
+- Changed several rule names (lex --> lx, bx --> bxc, gbx --> gbxc)
+- Escaped single quotes within words and lemmas
+
+Additionally, some minor format changes were made:
+- all categories are printed in lowercase and no longer appear within single quotes
+- changed the "." category to "period"
+- grammatical features are expressed with colons rather than brackets (s[dcl] --> s:dcl)

--- a/src/uk/ac/ed/easyccg/main/EasyCCG.java
+++ b/src/uk/ac/ed/easyccg/main/EasyCCG.java
@@ -55,7 +55,7 @@ public class EasyCCG
     @Option(shortName="i", defaultValue="tokenized", description = "(Optional) Input Format: one of \"tokenized\", \"POStagged\", \"POSandNERtagged\", \"gold\", \"deps\" or \"supertagged\"")
     String getInputFormat();
 
-    @Option(shortName="o", description = "Output Format: one of \"ccgbank\", \"html\", or \"prolog\"", defaultValue="ccgbank")
+    @Option(shortName="o", description = "Output Format: one of \"ccgbank\", \"html\", \"prolog\", or \"boxer\"", defaultValue="ccgbank")
     String getOutputFormat();
 
     @Option(shortName="l", defaultValue="70", description = "(Optional) Maximum length of sentences in words. Defaults to 70.")
@@ -106,7 +106,8 @@ public class EasyCCG
     CCGBANK(ParsePrinter.CCGBANK_PRINTER), 
     HTML(ParsePrinter.HTML_PRINTER), 
     SUPERTAGS(ParsePrinter.SUPERTAG_PRINTER),
-    PROLOG(ParsePrinter.PROLOG_PRINTER), 
+    PROLOG(ParsePrinter.PROLOG_PRINTER),
+    BOXER(ParsePrinter.BOXER_PRINTER),
     EXTENDED(ParsePrinter.EXTENDED_CCGBANK_PRINTER), 
     DEPS(new ParsePrinter.DependenciesPrinter());
     

--- a/src/uk/ac/ed/easyccg/syntax/ParsePrinter.java
+++ b/src/uk/ac/ed/easyccg/syntax/ParsePrinter.java
@@ -28,8 +28,9 @@ public abstract class ParsePrinter
   public String print(List<SyntaxTreeNode> parses, int id)
   {
     StringBuilder result = new StringBuilder();
-
-
+    if (id == 1) {
+    	printFileHeader(result);
+    }
 
     if (parses == null) {
       if (id > -1) printHeader(id, result);
@@ -54,6 +55,7 @@ public abstract class ParsePrinter
 
   public String print(SyntaxTreeNode entry, int id) {
     StringBuilder result = new StringBuilder();
+
     if (id > -1) printHeader(id, result);
 
     if (entry == null) {
@@ -512,7 +514,6 @@ w(2, 3, 'cake', 'cake', 'NN', 'I-NP', 'O', 'N').
 	    @Override
 	    void printParse(SyntaxTreeNode parse, int sentenceNumber, StringBuilder result)
 	    {
-	      printFileHeader(result);
 	      printDerivation(parse, sentenceNumber, result);
 	      result.append("\n");
 	    }

--- a/src/uk/ac/ed/easyccg/syntax/ParsePrinter.java
+++ b/src/uk/ac/ed/easyccg/syntax/ParsePrinter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import uk.ac.ed.easyccg.lemmatizer.Lemmatizer;
 import uk.ac.ed.easyccg.lemmatizer.MorphaStemmer;
 import uk.ac.ed.easyccg.syntax.Combinator.RuleType;
 import uk.ac.ed.easyccg.syntax.SyntaxTreeNode.SyntaxTreeNodeBinary;
@@ -19,6 +20,7 @@ public abstract class ParsePrinter
   public final static ParsePrinter CCGBANK_PRINTER = new CCGBankPrinter();
   public final static ParsePrinter HTML_PRINTER = new HTMLPrinter();
   public final static ParsePrinter PROLOG_PRINTER = new PrologPrinter();
+  public final static ParsePrinter BOXER_PRINTER = new BoxerPrinter();  
   public final static ParsePrinter EXTENDED_CCGBANK_PRINTER = new ExtendedCCGBankPrinter();
   public final static ParsePrinter SUPERTAG_PRINTER = new SupertagPrinter();
 
@@ -462,6 +464,162 @@ w(2, 3, 'cake', 'cake', 'NN', 'I-NP', 'O', 'N').
     }
 
   }
+
+  public static class BoxerPrinter extends ParsePrinter {	    
+	    private static String getRuleName(RuleType combinator) {
+	      // fa ba fc bx gfc gbx  conj
+	      switch (combinator) 
+	      {
+	      case FA : return "fa";
+	      case BA : return "ba";
+	      case FC : return "fc";
+	      case BX : return "bxc";
+	      case CONJ : return "conj";
+	      case RP : return "rp";
+	      case LP : return "lp";
+	      case GFC : return "gfc";
+	      case GBX : return "gbxc";
+	      }
+	      
+	      throw new RuntimeException("Unknown rule type: " + combinator);
+	    }
+	    
+	    @Override
+	    void printFileHeader(StringBuilder result)
+	    {
+	        result.append(":- op(601, xfx, (/)).\n" + 
+	          		":- op(601, xfx, (\\)).\n" + 
+	          		":- multifile ccg/2, id/2.\n" + 
+	          		":- discontiguous ccg/2, id/2.\n" + 
+	          		"\n");
+	        }
+	    
+	    @Override
+	    void printFailure(StringBuilder result)
+	    {
+	    }
+
+	    @Override
+	    void printHeader(int id, StringBuilder result)
+	    {
+	    }
+
+	    @Override
+	    void printFooter(StringBuilder result)
+	    {
+	    }
+
+	    @Override
+	    void printParse(SyntaxTreeNode parse, int sentenceNumber, StringBuilder result)
+	    {
+	      printFileHeader(result);
+	      printDerivation(parse, sentenceNumber, result);
+	      result.append("\n");
+	    }
+	    
+	    void printTerminal(SyntaxTreeNodeLeaf word, StringBuilder result) {
+	    	String featureList = buildFeatureList(word);
+	    	
+	    	String cat = word.getCategory().toString().toLowerCase();
+	        cat = cat.replaceAll("\\[([a-z]+)\\]", ":$1");
+	    	if (cat.equals(".")) {
+	    		cat = "period";
+	    	}
+	    	
+	    	result.append("t(" + cat + ", '" + escape(word.getWord()) + "', " + featureList + ")");
+	    }
+	    
+	    private String buildFeatureList(SyntaxTreeNodeLeaf word) {
+	    	String featureList = "[";
+	    	
+	    	// POS
+	    	String POS = word.getPos();
+	    	if (POS != null) {
+	    		featureList = featureList + "POS:'" + POS + "', ";
+	    	}
+	    	else { POS = ""; }
+	    	
+	    	// NER
+	    	if (word.getNER() != null) {
+	    		featureList = featureList + ", namex:'" + word.getNER() + "'";
+	    	}	    	
+	    	
+	    	// Lemma
+	    	featureList = featureList + "lemma:'" + Lemmatizer.lemmatize(escape(word.getWord()), POS) + "'";  	
+	    	featureList = featureList + "]";
+	    	return featureList;
+	    }
+	    
+	    // adds an escape character before single quotes
+	    private String escape(String string) {
+	    	string = string.replace("'", "\\'");
+	    	return string;
+	    }
+
+	    private void printDerivation(SyntaxTreeNode parse, int id, StringBuilder result)
+	    {
+	      result.append("ccg(" + id);
+	      parse.accept(new DerivationPrinter(result, id));
+	      result.append(").\n");
+	    }
+
+	    private class DerivationPrinter extends ParsePrinterVisitor {
+	      int currentIndent = 1;
+	      int wordNumber = 1;
+	      final int sentenceNumber;
+	      DerivationPrinter(StringBuilder result, int sentenceNumber) {
+	        super(result);
+	        this.sentenceNumber = sentenceNumber;
+	      }
+	      
+	      @Override
+	      public void visit(SyntaxTreeNodeBinary node)
+	      {
+	        // ba('S[dcl]',
+	        result.append(",\n");
+	        printIndent(currentIndent);
+	        String cat = node.getCategory().toString().toLowerCase();
+	        cat = cat.replaceAll("\\[([a-z]+)\\]", ":$1");
+	        result.append(getRuleName(node.getRuleType()) + "(" + cat);
+	        currentIndent++;    
+	        node.leftChild.accept(this);
+	        node.rightChild.accept(this);
+	        result.append(")");
+	        currentIndent--;
+	      }
+
+	      @Override
+	      public void visit(SyntaxTreeNodeUnary node)
+	      {
+	        // lx('N','NP',
+	        result.append(",\n");
+	        printIndent(currentIndent);
+	        String cat = node.getCategory().toString().toLowerCase();
+	        cat = cat.replaceAll("\\[([a-z]+)\\]", ":$1");
+	        String cat_c = node.child.getCategory().toString().toLowerCase();
+	        cat_c = cat_c.replaceAll("\\[([a-z]+)\\]", ":$1");
+	        result.append("lx(" + cat + ", " + cat_c);
+	        currentIndent++;        
+	        node.child.accept(this);
+	        result.append(")");
+	        currentIndent--;
+	      }
+	      
+	      @Override
+	      public void visit(SyntaxTreeNodeLeaf node)
+	      {
+	        result.append(",\n");
+	        printIndent(currentIndent);
+	        printTerminal(node,result);
+	        wordNumber++;
+	      }
+	      private void printIndent(int currentIndent)
+	      {
+	        result.append(Strings.repeat(" ", currentIndent));
+	      }
+	    }
+
+	  }
 
   static String getUnaryRuleName(Category initial, Category result) {
     if ((Category.NP.matches(initial) || Category.PP.matches(initial)) && result.isTypeRaised()) {


### PR DESCRIPTION
I have added a new printer for Boxer compatible output, at the request of its creator Johan Bos. The changes compared to the Prolog output are as follows:
- Terminal nodes are printed directly inside the tree, rather than just referenced
- Made terminal nodes a ternary predicate with its category, string and list containing all other features
- Input no longer needs to be POS & NER tagged, but these features will still appear in the output if available
- Changed Prolog file header
- Changed several rule names (lex --> lx, bx --> bxc, gbx --> gbxc)
- Escaped single quotes within words and lemmas

Additionally, some minor formatting changes were made:
- All categories are printed in lowercase and no longer appear within single quotes
- Changed the "." category to "period"
- Grammatical features are expressed with colons rather than brackets (s[dcl] --> s:dcl)
